### PR TITLE
Add taskExecutionId support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olakai/sdk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "This document demonstrates how to use the Olakai SDK with all its features.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/integrations/vercel-ai.ts
+++ b/src/integrations/vercel-ai.ts
@@ -450,6 +450,7 @@ export class VercelAIIntegration {
       response: toJsonValue(response),
       email: context.userEmail,
       chatId: context.chatId,
+      taskExecutionId: context.taskExecutionId,
       task: context.task,
       subTask: context.subTask,
       tokens: metadata.tokens?.total,

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -173,6 +173,7 @@ export function monitor<TArgs extends any[], TResult>(
           response: "",
           chatId: chatId,
           email: email,
+          taskExecutionId: options.taskExecutionId,
           task: options.task,
           subTask: options.subTask,
           blocked: true,
@@ -257,6 +258,7 @@ async function makeMonitoringCall<TArgs extends any[], TResult>(
     response: toJsonValue(result, options.sanitize),
     chatId: chatId,
     email: email,
+    taskExecutionId: options.taskExecutionId,
     tokens: 0,
     requestTime: Number(Date.now() - start),
     ...(options.task !== undefined && options.task !== ""
@@ -313,6 +315,7 @@ async function reportError<TArgs extends any[], TResult>(
           (errorInfo.stackTrace ? `\n${errorInfo.stackTrace}` : ""),
         chatId: chatId,
         email: email,
+        taskExecutionId: options.taskExecutionId,
         sensitivity: detectedSensitivity,
       };
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -280,6 +280,7 @@ export class OlakaiSDK {
       response: toJsonValue(response),
       email: config.defaultContext?.userEmail,
       chatId: this.sessionId,
+      taskExecutionId: config.defaultContext?.taskExecutionId,
       task: config.defaultContext?.task,
       subTask: config.defaultContext?.subTask,
       tokens: metadata.tokens?.total,
@@ -327,6 +328,7 @@ export class OlakaiSDK {
     olakaiLogger(`Sending event: ${JSON.stringify(params)}`, "info", this.config.debug);
     this.report(params.prompt, params.response, {
       email: params.userEmail,
+      taskExecutionId: params.taskExecutionId,
       task: params.task,
       subTask: params.subTask,
       tokens: params.tokens,
@@ -351,6 +353,7 @@ export class OlakaiSDK {
     response: any,
     options?: {
       email?: string;
+      taskExecutionId?: string;
       task?: string;
       subTask?: string;
       tokens?: number;
@@ -367,6 +370,7 @@ export class OlakaiSDK {
         response: toJsonValue(response, options?.sanitize),
         email: options?.email || "anonymous@olakai.ai",
         chatId: this.sessionId,
+        taskExecutionId: options?.taskExecutionId,
         task: options?.task,
         subTask: options?.subTask,
         tokens: options?.tokens || 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export type OlakaiEventParams = {
   userEmail?: string;
   userId?: string; // SDK client's user ID for tracking
   chatId?: string; // UUID - groups activities together in Olakai
+  taskExecutionId?: string; // Groups prompt requests by task execution
   task?: string;
   subTask?: string;
   tokens?: number;
@@ -16,6 +17,7 @@ export type MonitorPayload = {
   email?: string;
   userId?: string; // SDK client's user ID for tracking
   chatId?: string;
+  taskExecutionId?: string; // Groups prompt requests by task execution
   task?: string;
   subTask?: string;
   prompt: JsonValue;
@@ -100,6 +102,7 @@ export type MonitorOptions<TArgs extends any[], TResult> = {
   // Dynamic chat and user identification
   chatId?: string | ((args: TArgs) => string);
   email?: string | ((args: TArgs) => string);
+  taskExecutionId?: string; // Groups prompt requests by task execution
   task?: string;
   subTask?: string;
   sanitize?: boolean; // Whether to sanitize sensitive data
@@ -181,6 +184,7 @@ export type LLMWrapperConfig = {
     userEmail?: string;
     userId?: string; // SDK client's user ID for tracking
     chatId?: string;
+    taskExecutionId?: string; // Groups prompt requests by task execution
     task?: string;
     subTask?: string;
     customData?: Record<string, string | number | boolean | undefined>;
@@ -203,6 +207,7 @@ export type VercelAIContext = {
   userEmail?: string;
   userId?: string; // SDK client's user ID for tracking
   chatId?: string;
+  taskExecutionId?: string; // Groups prompt requests by task execution
   task?: string;
   subTask?: string;
   apiKey?: string; // Provider API key for cost tracking


### PR DESCRIPTION
## Summary
- Add optional `taskExecutionId` field to all monitoring payload types (`OlakaiEventParams`, `MonitorPayload`, `MonitorOptions`, `LLMWrapperConfig.defaultContext`, `VercelAIContext`)
- Flow the field through `event()`, `report()`, `wrap()` (sendMonitoring), `monitor()` (makeMonitoringCall, reportError), and Vercel AI integration
- Enables callers to group prompt requests belonging to the same task execution

## Test plan
- [x] `npm run build` passes with no errors
- [ ] Manually verify the field appears in payloads sent to `/api/monitoring/prompt`
- [ ] Verify backward compatibility — field is optional, existing callers unaffected