### PR TITLE
feat: add sessionId support for event grouping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olakai/sdk",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "This document demonstrates how to use the Olakai SDK with all its features.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -38,6 +38,7 @@ export class OlakaiSDK {
     monitoringEndpoint?: string;
     controlEndpoint?: string;
     enableControl?: boolean;
+    sessionId?: string;
     retries?: number;
     timeout?: number;
     debug?: boolean;
@@ -68,7 +69,7 @@ export class OlakaiSDK {
       debug: this.config.debug,
     });
 
-    this.sessionId = createId();
+    this.sessionId = config.sessionId ?? createId();
   }
 
   /**
@@ -328,6 +329,7 @@ export class OlakaiSDK {
     olakaiLogger(`Sending event: ${JSON.stringify(params)}`, "info", this.config.debug);
     this.report(params.prompt, params.response, {
       email: params.userEmail,
+      sessionId: params.sessionId,
       taskExecutionId: params.taskExecutionId,
       task: params.task,
       subTask: params.subTask,
@@ -353,6 +355,7 @@ export class OlakaiSDK {
     response: any,
     options?: {
       email?: string;
+      sessionId?: string;
       taskExecutionId?: string;
       task?: string;
       subTask?: string;
@@ -369,7 +372,7 @@ export class OlakaiSDK {
         prompt: toJsonValue(prompt, options?.sanitize),
         response: toJsonValue(response, options?.sanitize),
         email: options?.email || "anonymous@olakai.ai",
-        chatId: this.sessionId,
+        chatId: options?.sessionId ?? this.sessionId,
         taskExecutionId: options?.taskExecutionId,
         task: options?.task,
         subTask: options?.subTask,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,8 +2,7 @@ export type OlakaiEventParams = {
   prompt: string;
   response: string;
   userEmail?: string;
-  userId?: string; // SDK client's user ID for tracking
-  chatId?: string; // UUID - groups activities together in Olakai
+  sessionId?: string; // Groups activities into a session/conversation — maps to chatId on the wire
   taskExecutionId?: string; // Groups prompt requests by task execution
   task?: string;
   subTask?: string;


### PR DESCRIPTION
## Summary

- Add `sessionId` to constructor config (default for all events) and to `event()` params (per-event override)
- `sessionId` maps to `chatId` on the wire, enabling CHAT-scoped KPI grouping without exposing internal naming
- Remove `userId` from event params — user identity should be inferred from auth tokens by the API endpoint
- Bump version to 2.2.0

## Context

Needed for Kai AI Assistant self-monitoring: each conversation turn needs a `sessionId` so CHAT-scoped KPIs (like sentiment analysis) can group events into conversations.

The `userId` field was removed because in this use case (and generally), the user of the AI agent isn't necessarily a member of the monitoring account — user identity should be resolved server-side from auth tokens.

## Test plan

- [ ] `npm run build` passes
- [ ] Verify `sessionId` in constructor sets default for all events
- [ ] Verify per-event `sessionId` overrides constructor default
- [ ] Verify `chatId` field in wire payload uses `sessionId` value