### PR TITLE
feat: add OlakaiSDK.feedback() for explicit user ratings (v2.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the Olakai SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2026-04-09
+
+### Added
+
+- **`OlakaiSDK.feedback()`** — New public method for reporting explicit user feedback on a prior agent interaction. Fire-and-forget, like `event()`.
+  - Parameters: `sessionId`, `rating: "UP" | "DOWN"`, and optional `turnIndex`, `comment`, `userEmail`, `customData`
+  - Correlates with the original interaction via `sessionId` (+ optional `turnIndex`)
+  - Emits a feedback event with well-known `customData` keys the Olakai platform recognizes — no extra correlation work required
+- **`OlakaiFeedbackParams`** type exported alongside other event types
+
+### Example
+
+```typescript
+// Report when the end user clicks thumbs up on an assistant response
+olakai.feedback({
+  sessionId: conversationId,
+  turnIndex: 3,
+  rating: "UP",
+  comment: "Very helpful answer",
+});
+```
+
 ## [2.0.0] - 2025-01-07
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olakai/sdk",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "This document demonstrates how to use the Olakai SDK with all its features.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -8,6 +8,7 @@ import type {
   ControlAPIResponse,
   VercelAIContext,
   OlakaiEventParams,
+  OlakaiFeedbackParams,
 } from "./types";
 import { OpenAIProvider } from "./providers/openai";
 import { VercelAIIntegration } from "./integrations/vercel-ai";
@@ -342,6 +343,64 @@ export class OlakaiSDK {
       sanitize: false, // Don't sanitize for event-based usage
     }).catch((error) => {
       olakaiLogger(`Failed to track event: ${error}`, "error");
+    });
+  }
+
+  /**
+   * Report explicit user feedback on a prior agent interaction.
+   *
+   * Fire-and-forget, same pattern as {@link event}. Never throws — feedback
+   * failures must not break the host application.
+   *
+   * Feedback is correlated with the original interaction via `sessionId`
+   * (and optionally `turnIndex`), so the analytics layer can slice feedback
+   * by the conversation and turn it applies to. Under the hood, this emits
+   * a feedback event with well-known `customData` keys that the Olakai
+   * platform recognizes — no extra correlation work required on your side.
+   *
+   * @param params - Feedback parameters
+   *
+   * @example
+   * ```typescript
+   * // User clicks thumbs up on the assistant response at turn 3
+   * olakai.feedback({
+   *   sessionId: conversationId,
+   *   turnIndex: 3,
+   *   rating: "UP",
+   *   comment: "Very helpful answer",
+   * });
+   * ```
+   */
+  feedback(params: OlakaiFeedbackParams): void {
+    if (!this.initialized) {
+      olakaiLogger("SDK not initialized. Call init() first.", "warn");
+      return;
+    }
+
+    // Merge well-known feedback fields into customData. User-provided
+    // customData wins ties only for unknown keys — we intentionally do
+    // not let callers override the feedback markers.
+    const mergedCustomData: Record<string, string | number | boolean | undefined> = {
+      ...(params.customData ?? {}),
+      eventType: "feedback",
+      feedbackRating: params.rating,
+      ...(params.turnIndex !== undefined && { feedbackTurnIndex: params.turnIndex }),
+      ...(params.comment !== undefined && { feedbackComment: params.comment }),
+    };
+
+    olakaiLogger(
+      `Sending feedback: ${JSON.stringify({ sessionId: params.sessionId, rating: params.rating, turnIndex: params.turnIndex })}`,
+      "info",
+      this.config.debug,
+    );
+
+    this.report("[feedback]", "", {
+      email: params.userEmail,
+      sessionId: params.sessionId,
+      customData: mergedCustomData,
+      sanitize: false,
+    }).catch((error) => {
+      olakaiLogger(`Failed to send feedback: ${error}`, "error");
     });
   }
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -398,6 +398,9 @@ export class OlakaiSDK {
       email: params.userEmail,
       sessionId: params.sessionId,
       customData: mergedCustomData,
+      // Feedback events are metadata about a prior interaction, not a
+      // new interaction to evaluate — skip scoring.
+      shouldScore: false,
       sanitize: false,
     }).catch((error) => {
       olakaiLogger(`Failed to send feedback: ${error}`, "error");

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,30 @@ export type OlakaiEventParams = {
   customData?: Record<string, string | number | boolean | undefined>;
 };
 
+/**
+ * Parameters for reporting explicit user feedback on a prior agent interaction.
+ *
+ * Use this when your end user gives an explicit rating (thumbs up/down) on
+ * an assistant response. Feedback is correlated with the original interaction
+ * via `sessionId` — and optionally `turnIndex` — so the analytics layer can
+ * slice feedback by the turn it applies to.
+ */
+export type OlakaiFeedbackParams = {
+  /** Session/conversation ID of the interaction being rated. Must match
+   *  the `sessionId` used when reporting the original event. */
+  sessionId: string;
+  /** The rating itself. */
+  rating: "UP" | "DOWN";
+  /** Optional zero-based turn index within the session for turn-level correlation. */
+  turnIndex?: number;
+  /** Optional free-text comment alongside the rating. */
+  comment?: string;
+  /** Optional override for the user who gave the feedback. */
+  userEmail?: string;
+  /** Optional customer-defined fields for domain context. */
+  customData?: Record<string, string | number | boolean | undefined>;
+};
+
 export type MonitorPayload = {
   email?: string;
   userId?: string; // SDK client's user ID for tracking


### PR DESCRIPTION
## Summary

Adds a new public method `OlakaiSDK.feedback()` for customers to report explicit user feedback (thumbs up/down) on a prior agent interaction.

This fills a product gap: previously, customers who wanted to track user ratings had no SDK primitive — they had to invent their own convention on top of `event()` (e.g., using a fake prompt like `"[feedback]"` and inventing `customData` field names). That's exactly what Kai (Olakai's internal assistant) was doing, and when we audited it we realized we were reaching into internals rather than using what a real customer would have access to.

## API

```typescript
interface OlakaiFeedbackParams {
  sessionId: string;                // Which session/conversation
  rating: "UP" | "DOWN";            // The rating
  turnIndex?: number;               // Optional: which turn within the session
  comment?: string;                 // Optional: free-text feedback
  userEmail?: string;               // Optional: override default email
  customData?: Record<string, string | number | boolean | undefined>;
}

olakai.feedback(params: OlakaiFeedbackParams): void;  // fire-and-forget
```

## Correlation

Feedback is correlated with the original interaction via:
1. **`sessionId`** (required) — must match the `sessionId` of the original `event()`
2. **`turnIndex`** (optional) — for turn-level feedback within a multi-turn session

This aligns with the same linkage already used by CHAT-scoped KPIs on the Olakai platform.

## Wire format

Under the hood the SDK emits a monitoring event with well-known `customData` keys:

```json
{
  "prompt": "[feedback]",
  "response": "",
  "chatId": "<sessionId>",
  "customData": {
    "eventType": "feedback",
    "feedbackRating": "UP",
    "feedbackTurnIndex": 3,
    "feedbackComment": "...",
    // plus any customer-provided customData
  }
}
```

No server-side schema changes are required — the existing ingestion endpoint accepts this shape. The SDK just exposes a type-safe, documented primitive so customers don't invent their own field names.

## Contract

- **Fire-and-forget**: same as `event()`. Never throws. Monitoring failures don't break the host app.
- **Type-safe**: `rating` is strictly `"UP" | "DOWN"`
- **Additive**: no existing APIs changed
- **Well-known keys protected**: customer-provided `customData` is merged in first, then well-known feedback keys are written last, so callers cannot accidentally override the feedback markers

## Version

Bumped `2.3.0` → `2.4.0` (minor — new feature, backward compatible).

## Test plan

- [x] `npm run build` succeeds and `dist/src/sdk.js` contains the `feedback` method
- [ ] Smoke test: call `olakai.feedback(...)` from a test script and verify the event lands in monitoring
- [ ] Cross-SDK parity: matching `olakai_feedback()` added to Python SDK in a sibling PR

## Follow-ups (not in this PR)

- Python SDK parity (separate PR)
- `localnode-app` switches Kai to use this SDK method (bumps SDK version, deletes internal `reportFeedbackEvent`)
- Optional: teach the event pipeline / UI to recognize `customData.eventType === "feedback"` and render it specially in the activity feed