### PR TITLE
feat: route feedback() to /api/monitoring/feedback endpoint (v2.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Feedback events no longer create `PromptRequest` rows on the server; they are stored directly as `UserFeedback` records and correlated via `sessionId` (+ optional `turnIndex`).
   - Wire payload is now a clean `{ sessionId, rating, turnIndex?, comment?, email? }` — the `[feedback]` sentinel prompt and `customData.eventType === "feedback"` markers are gone.
   - Still fire-and-forget and never throws.
-- Added `feedbackEndpoint` to `SDKConfig` (derived automatically from the base domain — callers do not need to configure it).
+- Added `feedbackEndpoint` to `SDKConfig` (derived automatically from the base domain — callers do not need to configure it). The field is optional on `SDKConfig`; when unset at call-time, it is derived from `monitorEndpoint` by swapping `/prompt` → `/feedback` for backward compatibility with manually-constructed configs.
+- `params.customData` passed to `feedback()` is no longer forwarded over the wire. It was never part of the documented feedback contract, but callers relying on the old prompt-shaped payload should be aware it is now dropped.
 
 ### Migration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the Olakai SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - 2026-04-14
+
+### Changed
+
+- **`OlakaiSDK.feedback()` now posts to the dedicated `/api/monitoring/feedback` endpoint** instead of `/api/monitoring/prompt`.
+  - Public API (`olakai.feedback({...})` signature) is **unchanged** — this is a transparent upgrade for callers.
+  - Feedback events no longer create `PromptRequest` rows on the server; they are stored directly as `UserFeedback` records and correlated via `sessionId` (+ optional `turnIndex`).
+  - Wire payload is now a clean `{ sessionId, rating, turnIndex?, comment?, email? }` — the `[feedback]` sentinel prompt and `customData.eventType === "feedback"` markers are gone.
+  - Still fire-and-forget and never throws.
+- Added `feedbackEndpoint` to `SDKConfig` (derived automatically from the base domain — callers do not need to configure it).
+
+### Migration
+
+No code changes required for existing `olakai.feedback({...})` callers. Upgrade to 2.5.0 to stop polluting PromptRequest rows with feedback events.
+
 ## [2.4.0] - 2026-04-09
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olakai/sdk",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olakai/sdk",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "pnpm": "^10.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olakai/sdk",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "This document demonstrates how to use the Olakai SDK with all its features.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -117,7 +117,18 @@ async function makeAPICall(
   } else if (role === "control") {
     url = config.controlEndpoint;
   } else if (role === "feedback") {
-    url = config.feedbackEndpoint;
+    if (config.feedbackEndpoint) {
+      url = config.feedbackEndpoint;
+    } else {
+      // Backward-compat safety net: older callers may construct SDKConfig
+      // manually without setting feedbackEndpoint. Derive it from the
+      // monitoring endpoint (same host, swap the trailing path segment).
+      url = config.monitorEndpoint.replace(/\/prompt(\/?$)/, "/feedback$1");
+      olakaiLogger(
+        `feedbackEndpoint not configured; derived from monitorEndpoint: ${url}`,
+        "warn",
+      );
+    }
   }
 
   olakaiLogger(`Making API call to ${role} endpoint: ${url}`, "info", config.debug);

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,6 +4,7 @@ import type {
   MonitoringAPIResponse,
   ControlPayload,
   ControlAPIResponse,
+  FeedbackPayload,
 } from "./types";
 import packageJson from "../package.json";
 import { ConfigBuilder, olakaiLogger, sleep } from "./utils";
@@ -43,6 +44,7 @@ export async function initClient(
   configBuilder.apiKey(apiKey);
   configBuilder.monitorEndpoint(`${domainUrl}/api/monitoring/prompt`);
   configBuilder.controlEndpoint(`${domainUrl}/api/control/prompt`);
+  configBuilder.feedbackEndpoint(`${domainUrl}/api/monitoring/feedback`);
   configBuilder.retries(options.retries || 4);
   configBuilder.timeout(options.timeout || 30000);
   configBuilder.version(options.version || packageJson.version);
@@ -99,9 +101,9 @@ export function getConfig(): SDKConfig {
  * @throws {Error} if the internal logic fails
  */
 async function makeAPICall(
-  payload: MonitorPayload[] | ControlPayload,
-  role: "monitoring" | "control" = "monitoring",
-): Promise<MonitoringAPIResponse | ControlAPIResponse> {
+  payload: MonitorPayload[] | ControlPayload | FeedbackPayload,
+  role: "monitoring" | "control" | "feedback" = "monitoring",
+): Promise<MonitoringAPIResponse | ControlAPIResponse | void> {
   if (!config.apiKey) {
     throw new APIKeyMissingError("[Olakai SDK] API key is not set");
   }
@@ -114,6 +116,8 @@ async function makeAPICall(
     url = config.monitorEndpoint;
   } else if (role === "control") {
     url = config.controlEndpoint;
+  } else if (role === "feedback") {
+    url = config.feedbackEndpoint;
   }
 
   olakaiLogger(`Making API call to ${role} endpoint: ${url}`, "info", config.debug);
@@ -128,6 +132,19 @@ async function makeAPICall(
       signal: controller.signal,
     });
     olakaiLogger(`API call response: ${response.status}`, "info", config.debug);
+
+    if (role === "feedback") {
+      clearTimeout(timeoutId);
+      if (!response.ok) {
+        olakaiLogger(
+          `Feedback endpoint returned non-OK status: ${response.status}`,
+          "warn",
+        );
+        throw new HTTPError(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      return;
+    }
+
     let responseData: MonitoringAPIResponse | ControlAPIResponse = {} as
       | MonitoringAPIResponse
       | ControlAPIResponse;
@@ -203,10 +220,10 @@ async function makeAPICall(
  * @returns A promise that resolves to an object with success status
  */
 async function sendWithRetry(
-  payload: MonitorPayload[] | ControlPayload,
+  payload: MonitorPayload[] | ControlPayload | FeedbackPayload,
   maxRetries: number = config.retries!,
-  role: "monitoring" | "control" = "monitoring",
-): Promise<MonitoringAPIResponse | ControlAPIResponse> {
+  role: "monitoring" | "control" | "feedback" = "monitoring",
+): Promise<MonitoringAPIResponse | ControlAPIResponse | void> {
   let lastError: Error | null = null;
   let response: MonitoringAPIResponse | ControlAPIResponse = {} as
     | MonitoringAPIResponse
@@ -224,7 +241,7 @@ async function sendWithRetry(
         } else if (response.failureCount && response.failureCount > 0) {
           olakaiLogger(
             `Request partial success: ${response.successCount}/${response.totalRequests} requests succeeded`,
-            "info", 
+            "info",
             config.debug,
           );
           return response;
@@ -235,6 +252,9 @@ async function sendWithRetry(
           "control",
         )) as ControlAPIResponse;
         return response;
+      } else if (role === "feedback") {
+        await makeAPICall(payload, "feedback");
+        return;
       }
     } catch (err) {
       lastError = err as Error;
@@ -267,11 +287,25 @@ async function sendWithRetry(
  * @returns A promise that resolves when the payload is sent
  */
 export async function sendToAPI(
-  payload: MonitorPayload | ControlPayload,
-  role: "monitoring" | "control" = "monitoring",
+  payload: MonitorPayload | ControlPayload | FeedbackPayload,
+  role: "monitoring" | "control" | "feedback" = "monitoring",
 ): Promise<ControlAPIResponse | void> {
   if (!config.apiKey) {
     throw new APIKeyMissingError("[Olakai SDK] API key is not set");
+  }
+
+  if (role === "feedback") {
+    try {
+      await sendWithRetry(
+        payload as FeedbackPayload,
+        config.retries!,
+        "feedback",
+      );
+    } catch (error) {
+      olakaiLogger(`Error during feedback API call: ${error}`, "error");
+      throw error;
+    }
+    return;
   }
 
   if (role === "monitoring") {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -9,6 +9,7 @@ import type {
   VercelAIContext,
   OlakaiEventParams,
   OlakaiFeedbackParams,
+  FeedbackPayload,
 } from "./types";
 import { OpenAIProvider } from "./providers/openai";
 import { VercelAIIntegration } from "./integrations/vercel-ai";
@@ -56,6 +57,7 @@ export class OlakaiSDK {
         config.monitoringEndpoint || `${domainUrl}/api/monitoring/prompt`,
       controlEndpoint:
         config.controlEndpoint || `${domainUrl}/api/control/prompt`,
+      feedbackEndpoint: `${domainUrl}/api/monitoring/feedback`,
       enableControl: config.enableControl ?? false, // Default: disabled
       retries: config.retries ?? 4,
       timeout: config.timeout ?? 30000,
@@ -353,10 +355,9 @@ export class OlakaiSDK {
    * failures must not break the host application.
    *
    * Feedback is correlated with the original interaction via `sessionId`
-   * (and optionally `turnIndex`), so the analytics layer can slice feedback
-   * by the conversation and turn it applies to. Under the hood, this emits
-   * a feedback event with well-known `customData` keys that the Olakai
-   * platform recognizes — no extra correlation work required on your side.
+   * (and optionally `turnIndex`). Since v2.5.0 feedback is POSTed to a
+   * dedicated `/api/monitoring/feedback` endpoint — it no longer creates
+   * a synthetic PromptRequest row or pollutes `customData`.
    *
    * @param params - Feedback parameters
    *
@@ -377,15 +378,12 @@ export class OlakaiSDK {
       return;
     }
 
-    // Merge well-known feedback fields into customData. User-provided
-    // customData wins ties only for unknown keys — we intentionally do
-    // not let callers override the feedback markers.
-    const mergedCustomData: Record<string, string | number | boolean | undefined> = {
-      ...(params.customData ?? {}),
-      eventType: "feedback",
-      feedbackRating: params.rating,
-      ...(params.turnIndex !== undefined && { feedbackTurnIndex: params.turnIndex }),
-      ...(params.comment !== undefined && { feedbackComment: params.comment }),
+    const payload: FeedbackPayload = {
+      sessionId: params.sessionId,
+      rating: params.rating,
+      ...(params.turnIndex !== undefined && { turnIndex: params.turnIndex }),
+      ...(params.comment !== undefined && { comment: params.comment }),
+      ...(params.userEmail && { email: params.userEmail }),
     };
 
     olakaiLogger(
@@ -394,15 +392,9 @@ export class OlakaiSDK {
       this.config.debug,
     );
 
-    this.report("[feedback]", "", {
-      email: params.userEmail,
-      sessionId: params.sessionId,
-      customData: mergedCustomData,
-      // Feedback events are metadata about a prior interaction, not a
-      // new interaction to evaluate — skip scoring.
-      shouldScore: false,
-      sanitize: false,
-    }).catch((error) => {
+    // Fire-and-forget POST to the dedicated feedback endpoint.
+    // Never throws — feedback failures must not break the host application.
+    sendToAPI(payload, "feedback").catch((error) => {
       olakaiLogger(`Failed to send feedback: ${error}`, "error");
     });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,7 @@ export type SDKConfig = {
   apiKey: string;
   monitorEndpoint: string;
   controlEndpoint: string;
-  feedbackEndpoint: string;
+  feedbackEndpoint?: string;
   version: string;
   retries: number;
   timeout: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,11 +63,25 @@ export type SDKConfig = {
   apiKey: string;
   monitorEndpoint: string;
   controlEndpoint: string;
+  feedbackEndpoint: string;
   version: string;
   retries: number;
   timeout: number;
   debug: boolean;
   verbose: boolean;
+};
+
+/**
+ * Internal wire payload for the dedicated feedback endpoint
+ * (`/api/monitoring/feedback`). Not part of the public API — callers use
+ * {@link OlakaiFeedbackParams} with `OlakaiSDK.feedback()`.
+ */
+export type FeedbackPayload = {
+  sessionId: string;
+  rating: "UP" | "DOWN";
+  turnIndex?: number;
+  comment?: string;
+  email?: string;
 };
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,6 +80,11 @@ export class ConfigBuilder {
     return this;
   }
 
+  feedbackEndpoint(url: string): ConfigBuilder {
+    this.config.feedbackEndpoint = url;
+    return this;
+  }
+
   version(v: string): ConfigBuilder {
     this.config.version = v;
     return this;
@@ -115,6 +120,7 @@ export class ConfigBuilder {
       apiKey: "",
       monitorEndpoint: "",
       controlEndpoint: "",
+      feedbackEndpoint: "",
       version: "",
       retries: 3,
       timeout: 10000,


### PR DESCRIPTION
## Summary

- `olakai.feedback()` now POSTs to the dedicated `/api/monitoring/feedback` endpoint instead of wrapping `event()` → `/api/monitoring/prompt`
- Removes `[feedback]` sentinel prompt and all `customData.eventType/feedbackRating/feedbackTurnIndex/feedbackComment` markers
- Public API signature (`OlakaiFeedbackParams`, `OlakaiSDK.feedback`) unchanged
- Version 2.4.0 → 2.5.0

## Context

Stage 2 of the [native-feedback-architecture plan](../../tree/feat/native-feedback-endpoint-2.5.0/plans/native-feedback-architecture-2026-04-10). The server endpoint shipped in olakai-ai/localnode-app#2391 (merged 2026-04-15). SDK 2.4.0 callers will continue to work against the old endpoint until they upgrade.

## Wire format

```json
POST /api/monitoring/feedback
{ "sessionId": "...", "rating": "UP", "turnIndex": 3, "comment": "...", "email": "..." }
```

Optional keys omitted when undefined (matches server Zod schema).

## Notes

- `SDKConfig.feedbackEndpoint` is optional on the public type — derived at runtime from `monitorEndpoint` if unset (non-breaking for code constructing `SDKConfig` literals).
- `params.customData` on feedback is no longer forwarded — see CHANGELOG.
- Fire-and-forget contract preserved. Retries use SDK default (4).

## Follow-ups (not in this PR)

- Tighter retry policy for feedback role (e.g. no retry on 4xx)
- Stamp `feedbackTimestamp` at click-time in the SDK

## Test plan

- [x] `npm run build` passes
- [ ] Smoke test against staging once deployed: fire a feedback event, verify `UserFeedback` row created and no new `PromptRequest` row