### PR TITLE
feat: configurable on-prem host (v2.6.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,10 +106,22 @@ Re-exports all public APIs from `src/`:
 ### Configuration Pattern
 The SDK uses a singleton config initialized via `initClient()` or `olakaiConfig()`. The config includes:
 - API key (required)
-- Endpoints for monitoring and control (required)
+- Endpoints for monitoring, control, and feedback (derived from host; see below)
 - Retries (default: 4)
 - Timeout (default: 30000ms)
 - Debug/verbose flags
+
+### Host Resolution (on-prem support)
+Both `OlakaiSDK` (constructor) and `initClient()` resolve the target host with this precedence:
+1. **Explicit option** — `host` on `OlakaiSDK`, `domainUrl` on `initClient`
+2. **`OLAKAI_HOST` env var** — for on-prem deployments (e.g. `olakai.acme.com`)
+3. **Default** — `app.olakai.ai` (SaaS)
+
+The resolved host is used to derive `monitorEndpoint`, `controlEndpoint`, and
+`feedbackEndpoint` in one place. `process.env` access is guarded so the SDK still
+works in browsers. Full-URL overrides (`monitoringEndpoint` / `controlEndpoint`)
+remain supported and take precedence when provided — use them only when each
+endpoint must point at a different URL.
 
 ### Type Safety
 - The SDK uses strict TypeScript with `strict: true` in tsconfig.json`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to the Olakai SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.0] - 2026-05-04
+
+### Added
+
+- **On-prem host configuration.** The SDK now resolves its target host with the
+  precedence: explicit `host` constructor option → `OLAKAI_HOST` env var →
+  default `app.olakai.ai`. The resolved host is used to derive the monitoring,
+  control, and feedback endpoints in one place — useful for self-hosted Olakai
+  deployments.
+  - New `host?: string` option on `OlakaiSDK` constructor.
+  - `initClient(apiKey, domainUrl?, options?)` — `domainUrl` is now optional
+    and falls back to `OLAKAI_HOST` / default when omitted.
+  - `process.env` access is guarded so the SDK still works in browsers.
+- Backward compatible: existing `monitoringEndpoint` / `controlEndpoint`
+  overrides still work and take precedence when provided.
+
+### Example
+
+```typescript
+// SaaS (default)
+new OlakaiSDK({ apiKey });
+
+// On-prem via env var: OLAKAI_HOST=olakai.acme.com
+new OlakaiSDK({ apiKey });
+
+// On-prem via explicit option
+new OlakaiSDK({ apiKey, host: 'olakai.acme.com' });
+```
+
 ## [2.5.0] - 2026-04-14
 
 ### Changed

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -52,10 +52,11 @@ olakai("event", "ai_activity", {
 import { OlakaiSDK } from '@olakai/sdk';
 import OpenAI from 'openai';
 
-// Initialize SDK
+// Initialize SDK.
+// `host` defaults to "app.olakai.ai" (SaaS). For on-prem, set the
+// `OLAKAI_HOST` env var or pass `host: "olakai.acme.com"` explicitly.
 const olakai = new OlakaiSDK({
   apiKey: 'your-olakai-api-key',
-  monitoringEndpoint: 'https://app.olakai.ai/api/monitoring/prompt',
   enableControl: false // Optional Control API (default: false)
 });
 

--- a/README-V2.md
+++ b/README-V2.md
@@ -36,9 +36,9 @@ import { OlakaiSDK } from '@olakai/sdk';
 import OpenAI from 'openai';
 
 // 1. Initialize Olakai SDK
+//    `host` defaults to "app.olakai.ai"; for on-prem set OLAKAI_HOST or pass `host`.
 const olakai = new OlakaiSDK({
-  apiKey: 'your-olakai-api-key',
-  monitoringEndpoint: 'https://app.olakai.ai/api/monitoring/prompt'
+  apiKey: 'your-olakai-api-key'
 });
 await olakai.init();
 
@@ -91,10 +91,18 @@ When you wrap an LLM client, Olakai automatically captures:
 const olakai = new OlakaiSDK({
   // Required
   apiKey: 'your-olakai-api-key',
-  monitoringEndpoint: 'https://app.olakai.ai/api/monitoring/prompt',
 
-  // Optional
-  controlEndpoint: 'https://app.olakai.ai/api/control/prompt', // For Control API
+  // Optional — host configuration
+  host: 'app.olakai.ai',        // Hostname only. Default: "app.olakai.ai".
+                                // For on-prem, set `OLAKAI_HOST` env var
+                                // or pass an on-prem host (e.g. "olakai.acme.com").
+                                // Used to derive monitoring, control, and feedback endpoints.
+
+  // Optional — full endpoint overrides (rarely needed; `host` is preferred)
+  monitoringEndpoint: 'https://app.olakai.ai/api/monitoring/prompt',
+  controlEndpoint: 'https://app.olakai.ai/api/control/prompt',
+
+  // Optional — behavior
   enableControl: false,  // Enable Control API globally (default: false)
   retries: 4,            // API retry attempts (default: 4)
   timeout: 30000,        // Request timeout in ms (default: 30000)
@@ -102,6 +110,27 @@ const olakai = new OlakaiSDK({
   verbose: false         // Verbose logging (default: false)
 });
 ```
+
+#### On-prem deployments
+
+For on-prem (self-hosted) Olakai installations, point the SDK at your on-prem host
+in any of three ways (precedence: explicit `host` → `OLAKAI_HOST` env var → default):
+
+```typescript
+// 1. Pass `host` explicitly
+new OlakaiSDK({ apiKey, host: 'olakai.acme.com' });
+
+// 2. Set OLAKAI_HOST in the environment (Node.js)
+//    OLAKAI_HOST=olakai.acme.com node app.js
+new OlakaiSDK({ apiKey });
+
+// 3. SaaS default — no configuration needed
+new OlakaiSDK({ apiKey });
+```
+
+The resolved host is used for the monitoring, control, and feedback endpoints
+in one place. Use `monitoringEndpoint` / `controlEndpoint` only when you need
+each endpoint to point at a different URL.
 
 ### Wrapper Configuration
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ import { olakaiConfig } from "@olakai/sdk";
 // Initialize once in your app
 olakaiConfig({
   apiKey: "your-olakai-api-key",
-  // endpoint is optional, defaults to https://app.olakai.ai
+  // host is optional, defaults to "app.olakai.ai".
+  // For on-prem, set the `OLAKAI_HOST` env var or pass `host` explicitly.
   debug: false, // Set to true for development
 });
 ```
@@ -150,7 +151,8 @@ Initialize the SDK with your configuration.
 ```typescript
 olakaiConfig({
   apiKey: string;        // Required: Your Olakai API key
-  endpoint?: string;     // Optional: API endpoint (default: https://app.olakai.ai)
+  host?: string;         // Optional: hostname (default: "app.olakai.ai").
+                         // For on-prem, set `OLAKAI_HOST` env var or pass explicitly.
   debug?: boolean;       // Optional: Enable debug logging (default: false)
 });
 ```
@@ -334,7 +336,7 @@ try {
 **"Events not being tracked"**
 
 - Ensure `olakaiConfig()` was called first
-- Check your API key and endpoint URL
+- Check your API key and host (default: `app.olakai.ai`; on-prem deployments should set `OLAKAI_HOST`)
 - Enable debug mode to see detailed logs
 
 **"TypeScript errors"**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olakai/sdk",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "This document demonstrates how to use the Olakai SDK with all its features.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,17 +13,66 @@ import {
   APIKeyMissingError,
   ConfigNotInitializedError,
   HTTPError,
-  OlakaiBlockedError,
   URLConfigurationError,
 } from "./exceptions";
 
-let config: SDKConfig;
+let config: SDKConfig | undefined;
+
+export const DEFAULT_HOST = "app.olakai.ai";
+
+/**
+ * Read `OLAKAI_HOST` from the environment, guarding against browser
+ * runtimes where `process` is not defined.
+ */
+export function readOlakaiHostEnv(): string | undefined {
+  return typeof process !== "undefined" && process.env
+    ? process.env.OLAKAI_HOST
+    : undefined;
+}
+
+/**
+ * Resolve the base origin URL the SDK should call.
+ * Precedence: explicit `host` (or full base URL) → `OLAKAI_HOST` env → DEFAULT_HOST.
+ * Accepts a bare hostname ("olakai.acme.com") or a full URL ("https://olakai.acme.com");
+ * trailing slashes are stripped. `URL` is used to parse explicit values so that paths
+ * and query strings are dropped — only the origin is kept.
+ */
+export function resolveOriginUrl(explicit?: string): string {
+  const raw = explicit || readOlakaiHostEnv() || DEFAULT_HOST;
+  // Bare hostname → prepend https://. URL parsing requires a scheme.
+  const withScheme = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+  try {
+    return new URL(withScheme).origin;
+  } catch {
+    throw new URLConfigurationError(
+      `[Olakai SDK] Invalid host or URL: ${raw}`,
+    );
+  }
+}
+
+/**
+ * Build the three derived endpoints from a single resolved origin.
+ */
+export function buildEndpointsFromOrigin(origin: string): {
+  monitorEndpoint: string;
+  controlEndpoint: string;
+  feedbackEndpoint: string;
+} {
+  return {
+    monitorEndpoint: `${origin}/api/monitoring/prompt`,
+    controlEndpoint: `${origin}/api/control/prompt`,
+    feedbackEndpoint: `${origin}/api/monitoring/feedback`,
+  };
+}
 
 /**
  * Initialize the SDK
  * @param apiKey - The API key
- * @param domainUrl - The domain URL
- * @param options - The extra options for the SDKConfig
+ * @param domainUrl - The domain URL or bare hostname. If omitted, falls back
+ *   to the `OLAKAI_HOST` env var (e.g. on-prem host) or `app.olakai.ai`.
+ *   Only the origin is used; any path/query is dropped.
+ * @param options - Extra options. May include explicit `monitorEndpoint`,
+ *   `controlEndpoint`, and/or `feedbackEndpoint` to override the derived URLs.
  * @default options - {
  *  retries: 4,
  *  timeout: 30000,
@@ -36,53 +85,48 @@ let config: SDKConfig;
  */
 export async function initClient(
   apiKey: string,
-  domainUrl: string,
+  domainUrl?: string,
   options: Partial<SDKConfig> = {},
 ) {
-  // Extract known parameters
+  const origin = resolveOriginUrl(domainUrl);
+  const derived = buildEndpointsFromOrigin(origin);
+
   const configBuilder = new ConfigBuilder();
   configBuilder.apiKey(apiKey);
-  configBuilder.monitorEndpoint(`${domainUrl}/api/monitoring/prompt`);
-  configBuilder.controlEndpoint(`${domainUrl}/api/control/prompt`);
-  configBuilder.feedbackEndpoint(`${domainUrl}/api/monitoring/feedback`);
+  configBuilder.monitorEndpoint(options.monitorEndpoint ?? derived.monitorEndpoint);
+  configBuilder.controlEndpoint(options.controlEndpoint ?? derived.controlEndpoint);
+  configBuilder.feedbackEndpoint(options.feedbackEndpoint ?? derived.feedbackEndpoint);
   configBuilder.retries(options.retries || 4);
   configBuilder.timeout(options.timeout || 30000);
   configBuilder.version(options.version || packageJson.version);
   configBuilder.debug(options.debug || false);
   configBuilder.verbose(options.verbose || false);
-  config = configBuilder.build();
 
-  // Validate required configuration
-  if (
-    !config.monitorEndpoint ||
-    config.monitorEndpoint === "/api/monitoring/prompt"
-  ) {
-    throw new URLConfigurationError(
-      "[Olakai SDK] API URL is not set. Please provide a valid monitorEndpoint in the configuration.",
-    );
-  }
-  if (
-    !config.controlEndpoint ||
-    config.controlEndpoint === "/api/control/prompt"
-  ) {
-    throw new URLConfigurationError(
-      "[Olakai SDK] API URL is not set. Please provide a valid controlEndpoint in the configuration.",
-    );
-  }
-  if (!config.apiKey || config.apiKey.trim() === "") {
+  // Validate before assigning to the module singleton so a failed re-init
+  // doesn't leave a half-built config in place.
+  const built = configBuilder.build();
+  if (!built.apiKey || built.apiKey.trim() === "") {
     throw new APIKeyMissingError(
       "[Olakai SDK] API key is not set. Please provide a valid apiKey in the configuration.",
     );
   }
+  config = built;
   olakaiLogger(`Config: ${JSON.stringify(config)}`, "info", config.debug);
 }
 
 /**
- * Get the current configuration
- * @returns The current configuration
+ * Get the current configuration. Returns a shallow copy so callers cannot
+ * mutate the module-level singleton.
  * @throws {ConfigNotInitializedError} if the config is not initialized
  */
 export function getConfig(): SDKConfig {
+  return { ...requireConfig() };
+}
+
+/**
+ * Internal: assert config is initialized and narrow the type.
+ */
+function requireConfig(): SDKConfig {
   if (!config) {
     throw new ConfigNotInitializedError(
       "[Olakai SDK] Config is not initialized",
@@ -104,45 +148,34 @@ async function makeAPICall(
   payload: MonitorPayload[] | ControlPayload | FeedbackPayload,
   role: "monitoring" | "control" | "feedback" = "monitoring",
 ): Promise<MonitoringAPIResponse | ControlAPIResponse | void> {
-  if (!config.apiKey) {
-    throw new APIKeyMissingError("[Olakai SDK] API key is not set");
-  }
+  // Caller (`sendToAPI`) is the single gate for init/apiKey state. By the
+  // time we get here, both have been validated.
+  const cfg = requireConfig();
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), config.timeout);
+  const timeoutId = setTimeout(() => controller.abort(), cfg.timeout);
   let url: string = "";
 
   if (role === "monitoring") {
-    url = config.monitorEndpoint;
+    url = cfg.monitorEndpoint;
   } else if (role === "control") {
-    url = config.controlEndpoint;
+    url = cfg.controlEndpoint;
   } else if (role === "feedback") {
-    if (config.feedbackEndpoint) {
-      url = config.feedbackEndpoint;
-    } else {
-      // Backward-compat safety net: older callers may construct SDKConfig
-      // manually without setting feedbackEndpoint. Derive it from the
-      // monitoring endpoint (same host, swap the trailing path segment).
-      url = config.monitorEndpoint.replace(/\/prompt(\/?$)/, "/feedback$1");
-      olakaiLogger(
-        `feedbackEndpoint not configured; derived from monitorEndpoint: ${url}`,
-        "warn",
-      );
-    }
+    url = cfg.feedbackEndpoint;
   }
 
-  olakaiLogger(`Making API call to ${role} endpoint: ${url}`, "info", config.debug);
+  olakaiLogger(`Making API call to ${role} endpoint: ${url}`, "info", cfg.debug);
 
   try {
     const response = await fetch(url, {
       method: "POST",
       headers: {
-        "x-api-key": config.apiKey,
+        "x-api-key": cfg.apiKey,
       },
       body: JSON.stringify(payload),
       signal: controller.signal,
     });
-    olakaiLogger(`API call response: ${response.status}`, "info", config.debug);
+    olakaiLogger(`API call response: ${response.status}`, "info", cfg.debug);
 
     if (role === "feedback") {
       clearTimeout(timeoutId);
@@ -165,7 +198,7 @@ async function makeAPICall(
       responseData = (await response.json()) as ControlAPIResponse;
     }
 
-    olakaiLogger(`API response: ${JSON.stringify(responseData)}`, "info", config.debug);
+    olakaiLogger(`API response: ${JSON.stringify(responseData)}`, "info", cfg.debug);
 
     clearTimeout(timeoutId);
 
@@ -176,7 +209,7 @@ async function makeAPICall(
         olakaiLogger(
           `Request succeeded: ${JSON.stringify(responseData)}`,
           "info",
-          config.debug,
+          cfg.debug,
         );
         return responseData;
       } else if (response.status === ErrorCode.PARTIAL_SUCCESS) {
@@ -232,9 +265,10 @@ async function makeAPICall(
  */
 async function sendWithRetry(
   payload: MonitorPayload[] | ControlPayload | FeedbackPayload,
-  maxRetries: number = config.retries!,
+  maxRetries: number,
   role: "monitoring" | "control" | "feedback" = "monitoring",
 ): Promise<MonitoringAPIResponse | ControlAPIResponse | void> {
+  const cfg = requireConfig();
   let lastError: Error | null = null;
   let response: MonitoringAPIResponse | ControlAPIResponse = {} as
     | MonitoringAPIResponse
@@ -253,7 +287,7 @@ async function sendWithRetry(
           olakaiLogger(
             `Request partial success: ${response.successCount}/${response.totalRequests} requests succeeded`,
             "info",
-            config.debug,
+            cfg.debug,
           );
           return response;
         }
@@ -292,29 +326,53 @@ async function sendWithRetry(
 }
 
 /**
- * Send a payload to the API (simplified - no queueing)
+ * Send a payload to the API (simplified - no queueing).
+ *
+ * Error semantics:
+ * - `monitoring` and `feedback` are fire-and-forget telemetry — failures are
+ *   logged but never thrown to the caller, even if the SDK is misconfigured.
+ *   Telemetry must never break the host application.
+ * - `control` is awaited by the caller to decide whether to allow execution,
+ *   so errors propagate. Distinguishes `ConfigNotInitializedError` (init never
+ *   called) from `APIKeyMissingError` (init called but apiKey blank).
+ *
  * @param payload - The payload to send to the endpoint
  * @param role - The role of the API call
- * @returns A promise that resolves when the payload is sent
+ * @returns A promise that resolves when the payload is sent (or fails silently
+ *   for monitoring/feedback). For `control`, resolves to the API response.
  */
 export async function sendToAPI(
   payload: MonitorPayload | ControlPayload | FeedbackPayload,
   role: "monitoring" | "control" | "feedback" = "monitoring",
 ): Promise<ControlAPIResponse | void> {
-  if (!config.apiKey) {
-    throw new APIKeyMissingError("[Olakai SDK] API key is not set");
+  // Single gate for all three roles. Validates init state and apiKey.
+  // Inner helpers (`sendWithRetry`, `makeAPICall`) trust this check.
+  let cfg: SDKConfig;
+  try {
+    cfg = requireConfig();
+    if (!cfg.apiKey || cfg.apiKey.trim() === "") {
+      throw new APIKeyMissingError("[Olakai SDK] API key is not set");
+    }
+  } catch (error) {
+    if (role === "control") {
+      // Control gates execution — the caller needs the precise error type
+      // (ConfigNotInitializedError vs APIKeyMissingError) to react.
+      throw error;
+    }
+    // Fire-and-forget: log and bail.
+    olakaiLogger(
+      `[Olakai SDK] ${role} skipped: ${(error as Error).message}`,
+      "warn",
+    );
+    return;
   }
 
   if (role === "feedback") {
     try {
-      await sendWithRetry(
-        payload as FeedbackPayload,
-        config.retries!,
-        "feedback",
-      );
+      await sendWithRetry(payload as FeedbackPayload, cfg.retries, "feedback");
     } catch (error) {
       olakaiLogger(`Error during feedback API call: ${error}`, "error");
-      throw error;
+      // Fire-and-forget: swallow.
     }
     return;
   }
@@ -323,11 +381,10 @@ export async function sendToAPI(
     try {
       const response = (await sendWithRetry(
         [payload as MonitorPayload],
-        config.retries!,
+        cfg.retries,
         "monitoring",
       )) as MonitoringAPIResponse;
 
-      // Log any response information if present
       if (
         response.totalRequests !== undefined &&
         response.successCount !== undefined
@@ -336,27 +393,23 @@ export async function sendToAPI(
         olakaiLogger(
           `API call result: ${response.successCount}/${response.totalRequests} requests succeeded`,
           level,
-          level === "info" && config.debug,
+          level === "info" && cfg.debug,
         );
       }
     } catch (error) {
       olakaiLogger(`Error during monitoring API call: ${error}`, "error");
-      throw error;
+      // Fire-and-forget: swallow.
     }
-  } else if (role === "control") {
-    try {
-      return (await sendWithRetry(
-        payload as ControlPayload,
-        config.retries!,
-        "control",
-      )) as ControlAPIResponse;
-    } catch (error) {
-      if (error instanceof OlakaiBlockedError) {
-        throw error;
-      }
-      throw error;
-    }
-  } else {
-    throw new Error("[Olakai SDK] Invalid role");
+    return;
   }
+
+  if (role === "control") {
+    return (await sendWithRetry(
+      payload as ControlPayload,
+      cfg.retries,
+      "control",
+    )) as ControlAPIResponse;
+  }
+
+  throw new Error("[Olakai SDK] Invalid role");
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -31,16 +31,34 @@ export function readOlakaiHostEnv(): string | undefined {
 }
 
 /**
+ * Loopback hostnames default to http:// because local Olakai dev servers
+ * (e.g. `pnpm dev` on `localhost:3000`) don't usually have TLS.
+ * Match `localhost`, `127.0.0.1`, or IPv6 `[::1]`, with an optional port.
+ */
+const LOOPBACK_HOST_REGEX = /^(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
+
+/**
  * Resolve the base origin URL the SDK should call.
  * Precedence: explicit `host` (or full base URL) → `OLAKAI_HOST` env → DEFAULT_HOST.
  * Accepts a bare hostname ("olakai.acme.com") or a full URL ("https://olakai.acme.com");
  * trailing slashes are stripped. `URL` is used to parse explicit values so that paths
  * and query strings are dropped — only the origin is kept.
+ *
+ * Bare hostnames are assumed to be `https://`, except loopback hosts
+ * (`localhost`, `127.0.0.1`, `[::1]`, with optional port) which default to
+ * `http://` for local-dev convenience. Pass an explicit `https://` prefix to
+ * override.
  */
 export function resolveOriginUrl(explicit?: string): string {
   const raw = explicit || readOlakaiHostEnv() || DEFAULT_HOST;
-  // Bare hostname → prepend https://. URL parsing requires a scheme.
-  const withScheme = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+  let withScheme: string;
+  if (/^https?:\/\//i.test(raw)) {
+    withScheme = raw;
+  } else if (LOOPBACK_HOST_REGEX.test(raw)) {
+    withScheme = `http://${raw}`;
+  } else {
+    withScheme = `https://${raw}`;
+  }
   try {
     return new URL(withScheme).origin;
   } catch {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -13,7 +13,12 @@ import type {
 } from "./types";
 import { OpenAIProvider } from "./providers/openai";
 import { VercelAIIntegration } from "./integrations/vercel-ai";
-import { sendToAPI, initClient } from "./client";
+import {
+  sendToAPI,
+  initClient,
+  resolveOriginUrl,
+  buildEndpointsFromOrigin,
+} from "./client";
 import { createId, olakaiLogger, toJsonValue } from "./utils";
 import { OlakaiBlockedError } from "./exceptions";
 import packageJson from "../package.json";
@@ -22,6 +27,18 @@ import {
   BaseLLMProvider,
   GoogleProvider,
 } from "./providers";
+
+/**
+ * Best-effort wrapper around `resolveOriginUrl` that returns `undefined`
+ * instead of throwing, so callers can fall through to the next resolution step.
+ */
+function safeOrigin(url: string): string | undefined {
+  try {
+    return resolveOriginUrl(url);
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Main Olakai SDK class
@@ -33,12 +50,12 @@ export class OlakaiSDK {
   private vercelAI: VercelAIIntegration;
   private sessionId: string;
 
-  private static readonly DEFAULT_ENDPOINT = "https://app.olakai.ai";
-
   constructor(config: {
     apiKey: string;
+    host?: string;
     monitoringEndpoint?: string;
     controlEndpoint?: string;
+    feedbackEndpoint?: string;
     enableControl?: boolean;
     sessionId?: string;
     retries?: number;
@@ -46,18 +63,36 @@ export class OlakaiSDK {
     debug?: boolean;
     verbose?: boolean;
   }) {
-    // Build full config with defaults
-    const domainUrl = config.monitoringEndpoint
-      ? config.monitoringEndpoint.replace("/api/monitoring/prompt", "")
-      : OlakaiSDK.DEFAULT_ENDPOINT;
+    // Resolve the base origin. Precedence:
+    //   explicit `host` → origin of explicit `monitoringEndpoint` → `OLAKAI_HOST`
+    //   env var → DEFAULT_HOST.
+    // The fallback to `monitoringEndpoint`'s origin preserves 2.5.0 behavior
+    // for customers who only passed `monitoringEndpoint`: control/feedback
+    // continue to track the same host instead of silently reverting to SaaS.
+    const hostFromMonitoring =
+      !config.host && config.monitoringEndpoint
+        ? safeOrigin(config.monitoringEndpoint)
+        : undefined;
+    const origin = resolveOriginUrl(config.host ?? hostFromMonitoring);
+    const derived = buildEndpointsFromOrigin(origin);
+
+    const monitorEndpoint = config.monitoringEndpoint ?? derived.monitorEndpoint;
+    const controlEndpoint = config.controlEndpoint ?? derived.controlEndpoint;
+    const feedbackEndpoint = config.feedbackEndpoint ?? derived.feedbackEndpoint;
+
+    // Warn (don't throw) when endpoints come from different hosts. Customers
+    // sometimes legitimately need this (split monitoring and feedback hosts),
+    // but more often it's a copy-paste mistake — surface it loudly.
+    OlakaiSDK.warnOnMixedHosts(
+      { monitorEndpoint, controlEndpoint, feedbackEndpoint },
+      config.debug ?? false,
+    );
 
     this.config = {
       apiKey: config.apiKey,
-      monitorEndpoint:
-        config.monitoringEndpoint || `${domainUrl}/api/monitoring/prompt`,
-      controlEndpoint:
-        config.controlEndpoint || `${domainUrl}/api/control/prompt`,
-      feedbackEndpoint: `${domainUrl}/api/monitoring/feedback`,
+      monitorEndpoint,
+      controlEndpoint,
+      feedbackEndpoint,
       enableControl: config.enableControl ?? false, // Default: disabled
       retries: config.retries ?? 4,
       timeout: config.timeout ?? 30000,
@@ -76,15 +111,47 @@ export class OlakaiSDK {
   }
 
   /**
-   * Initialize the SDK (must be called before using wrap)
+   * Warn if the three endpoints don't share an origin. Each is genuinely
+   * configurable, but a mismatch is more often a misconfiguration than a
+   * deliberate choice, so we surface it.
+   */
+  private static warnOnMixedHosts(
+    endpoints: {
+      monitorEndpoint: string;
+      controlEndpoint: string;
+      feedbackEndpoint: string;
+    },
+    debug: boolean,
+  ): void {
+    const origins = new Set<string>();
+    for (const url of Object.values(endpoints)) {
+      try {
+        origins.add(new URL(url).origin);
+      } catch {
+        // Invalid URL surfaces later in the validation/HTTP layer.
+      }
+    }
+    if (origins.size > 1) {
+      olakaiLogger(
+        `[Olakai SDK] Mixed endpoint hosts detected (${[...origins].join(", ")}). ` +
+          `Most deployments should share a single host. Pass \`host\` instead of ` +
+          `per-endpoint overrides if you didn't intend this.`,
+        "warn",
+        debug,
+      );
+    }
+  }
+
+  /**
+   * Initialize the SDK (must be called before using wrap).
+   * Passes the already-resolved endpoints to `initClient` rather than
+   * re-deriving them from a stripped URL.
    */
   async init(): Promise<void> {
-    const domainUrl = this.config.monitorEndpoint.replace(
-      "/api/monitoring/prompt",
-      "",
-    );
-
-    await initClient(this.config.apiKey, domainUrl, {
+    await initClient(this.config.apiKey, undefined, {
+      monitorEndpoint: this.config.monitorEndpoint,
+      controlEndpoint: this.config.controlEndpoint,
+      feedbackEndpoint: this.config.feedbackEndpoint,
       retries: this.config.retries,
       timeout: this.config.timeout,
       debug: this.config.debug,

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,7 @@ export type SDKConfig = {
   apiKey: string;
   monitorEndpoint: string;
   controlEndpoint: string;
-  feedbackEndpoint?: string;
+  feedbackEndpoint: string;
   version: string;
   retries: number;
   timeout: number;


### PR DESCRIPTION
## Summary

Adds a `host` constructor option and `OLAKAI_HOST` environment variable so customer apps can point the SDK at an on-prem Olakai deployment instead of `app.olakai.ai`. The resolved host is used to derive monitoring, control, and feedback endpoints in one place, with each endpoint independently overridable.

**Resolution precedence:**
explicit `host` → origin of explicit `monitoringEndpoint` → `OLAKAI_HOST` env → default `app.olakai.ai`

## Usage

```ts
// SaaS (default, unchanged)
new OlakaiSDK({ apiKey });

// On-prem via env var
//   OLAKAI_HOST=olakai.acme.com node app.js
new OlakaiSDK({ apiKey });

// On-prem via explicit option
new OlakaiSDK({ apiKey, host: "olakai.acme.com" });
```

## Side cleanups bundled in

- **Robust URL parsing** — replaced fragile `monitoringEndpoint.replace("/api/monitoring/prompt", "")` string trick with `new URL(...).origin`. Trailing slashes, paths, and query strings are stripped correctly.
- **`feedbackEndpoint` constructor option** — previously hardcoded off the resolved host, now independently overridable like the others.
- **Mixed-host warning** — fires (but doesn't throw) when monitor/control/feedback resolve to different origins; usually a copy-paste mistake.
- **Fire-and-forget telemetry never throws** — `monitoring` and `feedback` log and return on misconfig; `control` still throws so callers can gate execution. Distinguishes `ConfigNotInitializedError` (init never called) from `APIKeyMissingError` (init called but apiKey blank).
- **No more URL round-tripping** — `OlakaiSDK.init()` passes resolved endpoints directly to `initClient` instead of stripping `monitorEndpoint` and re-deriving.
- **`client.getConfig()` returns a shallow copy** so callers can't mutate the module singleton.
- **Atomic `initClient`** — validates `apiKey` before assigning to the module singleton; a failed re-init no longer leaves a half-built config in place.
- **Honest types** — `let config: SDKConfig | undefined` matches reality; new internal `requireConfig()` helper narrows the type for inner helpers.
- **Single gate at `sendToAPI`** — inner helpers (`makeAPICall`, `sendWithRetry`) trust the public-boundary check rather than re-validating apiKey.

## Backward compatibility

- Existing `monitoringEndpoint` / `controlEndpoint` overrides still work and take precedence per-endpoint.
- Customers who passed **only** `monitoringEndpoint` in 2.5.0 continue to have control + feedback derived from the same host (origin inferred from `monitoringEndpoint` when no explicit `host` is provided). This was a deliberate fix during review to avoid silent split-brain configs.

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] Smoke tests: 10/10 host-resolution cases (default, bare hostname, full URL, URL with path, trailing slash, query string, env-var fallback, explicit-beats-env, derived endpoints, invalid-input throws `URLConfigurationError`)
- [x] Smoke tests: SDK integration (default, explicit `host`, `feedbackEndpoint` override + mixed-host warning, env var, mixed monitoring/control hosts, `init()` round-trip preserves all three endpoints, `monitoringEndpoint`-only customer regression check, `getConfig()` mutation isolation)
- [x] Pre-init error semantics: `control` throws `ConfigNotInitializedError`; `monitoring`/`feedback` log a warning and return silently
- [ ] Verify against on-prem deployment in staging
- [ ] Update `localnode-app/packages/config/sdk-versions.ts` to `2.6.0` after publish (already drafted, uncommitted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)